### PR TITLE
Refactor Dockerfile to use official Node image and install yt-dlp via pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,26 @@
-# Use a Node base image
+# Use an official Node base image that has apt-get
 FROM node:18
 
-# Install Python and pip
+# Install Python & pip, so we can install yt-dlp
 RUN apt-get update && apt-get install -y python3 python3-pip
 
-# Install yt-dlp globally
+# Install yt-dlp
 RUN pip3 install yt-dlp
 
-# (Optional) confirm the binary is accessible
-RUN ln -s /usr/local/bin/yt-dlp /usr/bin/yt-dlp
-
+# Set the working directory inside the container
 WORKDIR /app
 
-# Copy your Node files and install
+# Copy package.json and package-lock.json (if any)
 COPY package*.json ./
+
+# Install NPM dependencies
 RUN npm install
 
-# Copy in the rest of your code
+# Copy the rest of the source code
 COPY . .
 
-# Build (if needed)
-# RUN npm run build
-
+# Expose the port your app runs on (assuming it's 3000)
 EXPOSE 3000
+
+# Start the app
 CMD ["npm", "start"]

--- a/vercel.json
+++ b/vercel.json
@@ -2,14 +2,8 @@
     "version": 2,
     "builds": [
         {
-            "src": "app.js",
-            "use": "@now/node"
-        }
-    ],
-    "routes": [
-        {
-            "src": "/(.*)",
-            "dest": "app.js"
+            "src": "Dockerfile",
+            "use": "@vercel/docker"
         }
     ]
 }


### PR DESCRIPTION
Update the Dockerfile to utilize an official Node image and streamline the installation of yt-dlp using pip. Adjust the configuration for deployment with Vercel.